### PR TITLE
Used locking to make the WasapiCapture class prevent deadlock when it…

### DIFF
--- a/NAudioTests/Wasapi/AudioClientTests.cs
+++ b/NAudioTests/Wasapi/AudioClientTests.cs
@@ -187,7 +187,7 @@ namespace NAudioTests.Wasapi
             }
         }
  
-        [Test, MaxTime(3000)]
+        [Test]
         public void CanReuseWasapiCapture()
         {
             using (var wasapiClient = new WasapiCapture())


### PR DESCRIPTION
… gets a call to stop recording before it has had a chance to start capturing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/naudio/1)
<!-- Reviewable:end -->
